### PR TITLE
feat(label): enable method chaining for setName and setColor

### DIFF
--- a/src/entities/label.entity.ts
+++ b/src/entities/label.entity.ts
@@ -1,7 +1,7 @@
 export interface ILabel {
   getName(): string;
-  setName(name: string): string;
+  setName(name: string): ILabel;
   getId(): string;
   getColor(): string;
-  setColor(color: string): string;
+  setColor(color: string): ILabel;
 }


### PR DESCRIPTION
Return `this` in `setName` and `setColor` methods to support chaining.
Example: `setName("name").setColor("red")`.
Maintains backward compatibility.